### PR TITLE
Enhance `toFile` subtask to allow for appending

### DIFF
--- a/src/main/scala/net/virtualvoid/sbt/graph/util/IOUtil.scala
+++ b/src/main/scala/net/virtualvoid/sbt/graph/util/IOUtil.scala
@@ -27,6 +27,9 @@ object IOUtil {
   def writeToFile(string: String, file: File): Unit =
     sbt.IO.write(file, string, utf8)
 
+  def appendToFile(string: String, file: File): Unit =
+    sbt.IO.write(file, string, utf8, true)
+
   def saveResource(resourcePath: String, to: File): Unit = {
     val is = getClass.getClassLoader.getResourceAsStream(resourcePath)
     require(is ne null, s"Couldn't load '$resourcePath' from classpath.")


### PR DESCRIPTION
In multiproject setting, if we need to extract quickly all dependencies
and save to the file, it becomes unncessairly cumbersome.
Added `-a|--append` to allow for appending the tree/list to the file, if
it already exists.