### PR TITLE
Downgrade sbt version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.6
+sbt.version=1.2.7


### PR DESCRIPTION
Otherwise I'm experiencing this for projects that run sbt < 1.3.x:
```
[info] Loading project definition from [...]/project
[error] java.lang.NoSuchMethodError: sbt.package$.singleFileJsonFormatter()Lsjsonnew/JsonFormat;
[error] 	at net.virtualvoid.sbt.graph.DependencyGraphKeys.$init$(DependencyGraphKeys.scala:26)
[error] 	at net.virtualvoid.sbt.graph.DependencyGraphKeys$.<init>(DependencyGraphKeys.scala:113)
[error] 	at net.virtualvoid.sbt.graph.DependencyGraphKeys$.<clinit>(DependencyGraphKeys.scala)
[error] 	at net.virtualvoid.sbt.graph.DependencyGraphSettings$.<init>(DependencyGraphSettings.scala:70)
[error] 	at net.virtualvoid.sbt.graph.DependencyGraphSettings$.<clinit>(DependencyGraphSettings.scala)
[error] 	at net.virtualvoid.sbt.graph.DependencyGraphPlugin$.projectSettings(DependencyGraphPlugin.scala:25)
[error] 	at sbt.internal.Load$.$anonfun$resolveProject$3(Load.scala:1025)
[error] 	at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:241)
[error] 	at scala.collection.immutable.List.foreach(List.scala:389)
[error] 	at scala.collection.TraversableLike.flatMap(TraversableLike.scala:241)
[error] 	at sbt.internal.Load$.loadTransitive(Load.scala:915)
...
[error] 	at xsbt.boot.Launch$$anonfun$apply$1.apply(Launch.scala:37)
[error] 	at xsbt.boot.Launch$.launch(Launch.scala:120)
[error] 	at xsbt.boot.Launch$.apply(Launch.scala:20)
[error] 	at xsbt.boot.Boot$.runImpl(Boot.scala:56)
[error] 	at xsbt.boot.Boot$.main(Boot.scala:18)
[error] 	at xsbt.boot.Boot.main(Boot.scala)
[error] java.lang.NoSuchMethodError: sbt.package$.singleFileJsonFormatter()Lsjsonnew/JsonFormat;
```